### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,4 +1,6 @@
 name: Notify Discord on GitHub Events
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Kali-in-Batch/kali-in-batch/security/code-scanning/1](https://github.com/Kali-in-Batch/kali-in-batch/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Since the workflow only reads repository metadata (e.g., event details, issue titles, etc.) and does not modify any GitHub resources, we will set `contents: read` as the only permission. This ensures that the workflow adheres to the principle of least privilege.

The `permissions` block will be added at the root level of the workflow, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
